### PR TITLE
Don't use types as traits in macros

### DIFF
--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -70,7 +70,7 @@ impl Buffer {
 }
 
 macro_rules! string {
-    ($($kind:ty),*) => (
+    ($($kind:path),*) => (
         $(
             impl<'l> $kind for &'l str {
                 #[inline]


### PR DESCRIPTION
Hello.

We've found that this crate is affected by an upcoming bugfix in `rustc` - https://github.com/rust-lang/rust/pull/48502 (`ty` fragments are no longer accepted as traits in trait impls).
This PR fixes the deprecated use of `ty`.